### PR TITLE
Allow iteration over available file names

### DIFF
--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -4,7 +4,10 @@ extern crate phf;
 include!(concat!(env!("OUT_DIR"), "/data.rs"));
 
 fn main() {
-    println!("{:?}", FILES.get("data/foo"))
+    println!("{:?}", FILES.get("data/foo"));
+    for name in FILES.file_names() {
+        println!("Found: {}", name);
+    }
     // for (k, v) in FILES.entries() {
     //    println!("{}: {} bytes", k, v.len());
     // }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -37,6 +37,12 @@ impl Files {
         self.files.contains_key(path)
     }
 
+    /// Returns an iterator over all available file names.  Does not
+    /// decompress any compressed data.
+    pub fn file_names(&self) -> FileNames {
+        FileNames { iter: self.files.keys() }
+    }
+
     pub fn get(&self, path: &str) -> io::Result<Cow<'static, [u8]>> {
         let key = as_key(path);
         match self.files.get(key.borrow() as &str) {
@@ -81,5 +87,20 @@ impl Files {
             }
             None => Err(Error::new(ErrorKind::NotFound, "Key not found")),
         }
+    }
+}
+
+/// Iterates over the file names available for `Files` object.
+pub struct FileNames<'a> {
+    /// Our internal iterator.  We wrap this in a nice struct so our
+    /// caller doesn't need to know the details.
+    iter: phf::map::Keys<'a, &'static str, (Compression, &'static [u8])>,
+}
+
+impl<'a> Iterator for FileNames<'a> {
+    type Item = &'static str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|s| *s)
     }
 }


### PR DESCRIPTION
(Thank you for the very handy library! I'm going to use includedir in faradayio/conductor to implement a Rails-style `generate` subcommand. Please let me know if you have any feedback on this patch; I'm happy to make changes.)

Your example program included an unimplemented `entries` method.  I chose not to implement `entries` because iterating over it would require decompressing any large files stored in the map.

Instead, I've provided a `file_names` API that provides just the names of the files in the map, which the caller can look up (and potentially decompress) if they wish.

I implemented a custom iterator wrapper to hide the implementation details from the caller.
