### PR TITLE
Fix/unused import warning

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -120,8 +120,7 @@ impl IncludeDir {
         let mut out_file = BufWriter::new(File::create(&out_path)?);
 
         write!(&mut out_file,
-               "use includedir::*;\n\
-                pub static {}: Files = Files {{\n\
+               "pub static {}: ::includedir::Files = ::includedir::Files {{\n\
                     files:  ",
                 self.name)?;
 
@@ -131,7 +130,7 @@ impl IncludeDir {
             let include_path = format!("{}", self.manifest_dir.join(path).display());
 
             map.entry(as_key(&name).into_owned(),
-                      &format!("(Compression::{}, \
+                      &format!("(::includedir::Compression::{}, \
                                 include_bytes!(\"{}\") as &'static [u8])",
                                compression, as_key(&include_path)));
         }


### PR DESCRIPTION
Rust complains that the `use includedir::*` is unused, if the file where the generated file is included already includes the `Files` and `Compression` beforehand, like so:

```
use includedir::Files;
use includedir::Compression;

include!(concat!(env!("OUT_DIR"), "/data.rs"));

```

```
warning: unused import: `includedir::*`
 --> /.../target/debug/build/rust-angular-0c0f3d27bab18c60/out/data.rs:1:5
  |
1 | use includedir::*;
  |     ^^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default
```